### PR TITLE
Use Scheduler 1.0 not dev with patches for new hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
 branches:
   only:
     - /^8\.([0-9]+|x)\-[0-9]+\.([0-9]+|x)$/
-    - fix/use-scheduler-hooks
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 branches:
   only:
     - /^8\.([0-9]+|x)\-[0-9]+\.([0-9]+|x)$/
+    - fix/use-scheduler-hooks
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "drupal/scheduler": "dev-1.x"
+    "drupal/scheduler": "1.0"
   },
   "extra": {
     "patches": {
       "drupal/scheduler": {
-        "Scheduler integration with core Content moderation": "https://www.drupal.org/files/issues/2019-04-23/2798689-202.content_moderation_hooks.patch",
-        "Load latest revision of node when publishing and unpublishing": "https://www.drupal.org/files/issues/2019-04-18/3049070-1.load_latest_revision.patch"
+        "Scheduler integration with core Content moderation": "https://www.drupal.org/files/issues/2019-04-26/2798689-203.content_moderation_hooks_for_1.0_not_dev.patch",
+        "Load latest revision of node when publishing and unpublishing": "https://www.drupal.org/files/issues/2019-04-26/3049070-14.load_latest_revision_for_1.0_not_dev.patch"
       }
     }
   }

--- a/drupalci.yml
+++ b/drupalci.yml
@@ -7,8 +7,8 @@ build:
         halt-on-fail: true
       host_command:
         commands:
-          - 'cd modules/contrib/scheduler; sudo -u www-data curl "https://www.drupal.org/files/issues/2019-04-23/2798689-202.content_moderation_hooks.patch" | sudo -u www-data patch -p1'
-          - 'cd modules/contrib/scheduler; sudo -u www-data curl "https://www.drupal.org/files/issues/2019-04-18/3049070-1.load_latest_revision.patch" | sudo -u www-data patch -p1'
+          - 'cd modules/contrib/scheduler; sudo -u www-data curl "https://www.drupal.org/files/issues/2019-04-26/2798689-203.content_moderation_hooks_for_1.0_not_dev.patch" | sudo -u www-data patch -p1'
+          - 'cd modules/contrib/scheduler; sudo -u www-data curl "https://www.drupal.org/files/issues/2019-04-26/3049070-14.load_latest_revision_for_1.0_not_dev.patch" | sudo -u www-data patch -p1'
       csslint:
         halt-on-fail: false
       eslint:


### PR DESCRIPTION
These patches (which apply the new hooks to Scheduler 1.0 not dev) should allow you to commit the implementation of the new hooks to your main codebase and release beta2. They match the patch on #17 of https://www.drupal.org/project/scheduler_content_moderation_integration/issues/3049346#comment-13085081