### PR TITLE
Issue #3080069: Do not assume _none is in the state options list when counting

### DIFF
--- a/scheduler_content_moderation_integration.module
+++ b/scheduler_content_moderation_integration.module
@@ -171,7 +171,8 @@ function scheduler_content_moderation_integration_scheduler_hide_publish_on_fiel
   if ($moderation_information->isModeratedEntity($node)) {
     // If no moderation transitions are available for publish_state then hide
     // the publish_on scheduler field.
-    $return = (count($form['publish_state']['widget'][0]['#options']) <= 1);
+    $options_without_none = array_diff_key($form['publish_state']['widget'][0]['#options'], ['_none' => '']);
+    $return = (count($options_without_none) == 0);
   }
   return $return;
 }
@@ -190,7 +191,8 @@ function scheduler_content_moderation_integration_scheduler_hide_unpublish_on_fi
   if ($moderation_information->isModeratedEntity($node)) {
     // If no moderation transitions are available for unpublish_state then hide
     // the unpublish_on scheduler field.
-    $return = (count($form['unpublish_state']['widget'][0]['#options']) <= 1);
+    $options_without_none = array_diff_key($form['unpublish_state']['widget'][0]['#options'], ['_none' => '']);
+    $return = (count($options_without_none) == 0);
   }
   return $return;
 }

--- a/tests/src/Kernel/HookImplementationTest.php
+++ b/tests/src/Kernel/HookImplementationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\Tests\scheduler_content_moderation_integration\Kernel;
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests the Scheduler hook functions implemented by this module.
+ *
+ * @group scheduler_content_moderation_integration
+ */
+class HookImplementationTest extends SchedulerContentModerationTestBase {
+
+  /**
+   * A node of a type which is enabled for moderation.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $moderatedNode;
+
+  /**
+   * A node of a type which is not enabled for moderation.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $nonModeratedNode;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create a test 'Example' node which will be moderated.
+    $this->moderatedNode = Node::create([
+      'type' => 'example',
+      'title' => 'Example content is moderated',
+    ]);
+
+    // Create a test 'Other' node which will not be moderated.
+    $this->nonModeratedNode = Node::create([
+      'type' => 'other',
+      'title' => 'Other is not moderated',
+    ]);
+  }
+
+  /**
+   * Tests if the Scheduler Publish-on and Unpublish-on fields should be hidden.
+   *
+   * @dataProvider hideSchedulerFieldsProvider
+   */
+  public function testHookHideSchedulerFields($expected, $nodeChoice, $options) {
+    $node = $this->$nodeChoice;
+    $form = [];
+    $form['publish_state']['widget'][0]['#options'] = $options;
+    $form['unpublish_state']['widget'][0]['#options'] = $options;
+
+    $result = scheduler_content_moderation_integration_scheduler_hide_publish_on_field($form, [], $node);
+    $this->assertEquals($expected, $result, sprintf('Hide the publish-on field: Expected %s, Result %s', $expected ? 'Yes' : 'No', $result ? 'Yes' : 'No'));
+
+    $result = scheduler_content_moderation_integration_scheduler_hide_unpublish_on_field($form, [], $node);
+    $this->assertEquals($expected, $result, sprintf('Hide the unpublish-on field: Expected %s, Result %s', $expected ? 'Yes' : 'No', $result ? 'Yes' : 'No'));
+  }
+
+  /**
+   * Data provider for self:testHookHideSchedulerFields().
+   */
+  public function hideSchedulerFieldsProvider() {
+    return [
+      // Two states in addition to _none. Should not hide the fields.
+      [FALSE, 'moderatedNode', ['_none' => 'None', 'Some state', 'Not hidden']],
+
+      // Just one state in addition to _none. Should not hide the fields.
+      [FALSE, 'moderatedNode', ['_none' => 'Nothing', 'Will not be hidden']],
+
+      // Just one state, does not include _none. Should not hide the fields.
+      [FALSE, 'moderatedNode', ['The only state']],
+
+      // The only state is 'None'. This should cause the fields to be hidden.
+      [TRUE, 'moderatedNode', ['_none' => 'Nothing']],
+
+      // No states at all. This should cause the fields to be hidden.
+      [TRUE, 'moderatedNode', []],
+
+      // Content type is not moderated. Should not hide the fields.
+      [FALSE, 'nonModeratedNode', ['_none' => 'Nothing']],
+    ];
+  }
+
+}


### PR DESCRIPTION
d.o. issue https://www.drupal.org/project/scheduler_content_moderation_integration/issues/3080069 